### PR TITLE
Disable generative AI in Google Colab

### DIFF
--- a/pvlib-introduction-part-1.ipynb
+++ b/pvlib-introduction-part-1.ipynb
@@ -408,7 +408,8 @@
  ],
  "metadata": {
   "colab": {
-   "provenance": []
+   "provenance": [],
+   "generative_ai_disabled": true,
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",

--- a/pvlib-introduction-part-2.ipynb
+++ b/pvlib-introduction-part-2.ipynb
@@ -345,7 +345,8 @@
  ],
  "metadata": {
   "colab": {
-   "provenance": []
+   "provenance": [],
+   "generative_ai_disabled": true,
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",


### PR DESCRIPTION
During the tutorial, it was a rather big hindrance that the students were getting auto-complete suggestions by AI, which often were not correct. This meant that the instructors had to help a lot more to undo these code suggestions and that the students spent less time thinking about what they were actually coding.

Google now allows disabling generative AI in Google Colab: https://github.com/googlecolab/colabtools/issues/4834#

@uakkoseo, @kandersolar, @shirubana, @mikofski 